### PR TITLE
Compile the PHP wasm with modularize

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -29,10 +29,11 @@ emmake make
 mkdir out
 emcc -O3 -I . -I Zend -I main -I TSRM/ ../pib_eval.c -o pib_eval.o
 emcc -O3 \
-  -s WASM=1 \
   -s ENVIRONMENT=web \
   -s EXPORTED_FUNCTIONS='["_pib_eval", "_php_embed_init", "_zend_eval_string", "_php_embed_shutdown"]' \
   -s EXTRA_EXPORTED_RUNTIME_METHODS='["ccall"]' \
+  -s MODULARIZE=1 \
+  -s EXPORT_NAME="'PHP'" \
   -s TOTAL_MEMORY=134217728 \
   -s ASSERTIONS=0 \
   -s INVOKE_RUN=0 \

--- a/build.sh
+++ b/build.sh
@@ -1,14 +1,20 @@
 #!/bin/bash
 
+PHP_VERSION=php-7.3.0beta2
+CURRENTDIR=$(dirname "$0")
+
+cd $CURRENTDIR
+
 echo "Get PHP source"
-wget https://downloads.php.net/~cmb/php-7.3.0beta2.tar.xz
-tar xf php-7.3.0beta2.tar.xz
+wget https://downloads.php.net/~cmb/$PHP_VERSION.tar.xz
+tar xf $PHP_VERSION.tar.xz
+rm $PHP_VERSION.tar.xz
 
 echo "Apply patch"
 patch -p0 -i mods.diff
 
 echo "Configure"
-cd php-7.3.0beta2
+cd $PHP_VERSION
 emconfigure ./configure \
   --disable-all \
   --disable-cgi \

--- a/index.html
+++ b/index.html
@@ -97,6 +97,7 @@
         </div>
     </div>
     <a href="https://github.com/oraoto/pib"><img style="z-index: 1;position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub"></a>
+    <script type="text/javascript" src="php.js"></script>
     <script type='text/javascript'>
         var editor = ace.edit("editor");
         editor.setTheme("ace/theme/github");
@@ -117,6 +118,8 @@
         var output_area = document.getElementById('output').contentWindow.document;
         output_area.open();
 
+        var phpModule;
+
         function init() {
 
             output_area.close();
@@ -135,7 +138,7 @@
                 }
                 code = code.replace(/^\s*<\?php/, "") // remove <?php
                 code = code + "\necho PHP_EOL;" // flush line buffer
-                let ret = Module.ccall('pib_eval', 'number', ["string"], [code])
+                let ret = phpModule.ccall('pib_eval', 'number', ["string"], [code])
                 if (ret != 0) {
                     output_area.write("Error, please check your code")
                 }
@@ -143,9 +146,9 @@
             });
         }
 
-        var Module = {
+        var phpModuleOptions = {
             preRun: [
-                function() {ENV.USE_ZEND_ALLOC = "0"}
+                function() {phpModule.asmLibraryArg._putenv('USE_ZEND_ALLOC=0')}
             ],
             postRun: [init],
             print: function (text) {
@@ -162,10 +165,9 @@
                 }
                 output_area.write(text)
             }
-
         };
+        phpModule = PHP(phpModuleOptions);
     </script>
-    <script async type="text/javascript" src="php.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
When having multiple emscripten-generated wasm modules on the same page, they have to be separated with different module names.

After compiling with `MODULARIZE`, one can instantiate the wasm module the following way:

```
var phpModule = PHP(moduleOptions);
phpModule.ccall('pib_eval', 'number', ["string"], [code])
```
 