### PR TITLE
Checkout only a single branch og the PHP source to reduce bandwidth

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@ PHP_BRANCH=PHP-7.4
 
 if [[ ! -d php-src ]]; then
     echo "Get PHP source"
-    git clone https://github.com/php/php-src.git
+    git clone https://github.com/php/php-src.git --branch $PHP_BRANCH --single-branch --no-tags
 fi
 
 # Install autoconf
@@ -17,7 +17,6 @@ fi
 echo "Configure"
 
 cd php-src
-git checkout $PHP_BRANCH
 ./buildconf
 emconfigure ./configure \
   --disable-all \


### PR DESCRIPTION
To reduce bandwidth and optimize the checkout process of the PHP source, we can only fetch the necessary branch. Other branches and tags are not needed